### PR TITLE
Different background shapes

### DIFF
--- a/src/fitting.jl
+++ b/src/fitting.jl
@@ -47,6 +47,15 @@ function norm_uniform(x::Real,p::NamedTuple,b_name::Symbol)
 
 end
  
+function exp_stable(x::Float64)
+
+    
+    if (abs(x)<1E-6)
+        return 1 + x + x^2/2+x^3/6
+    else
+        return exp(x)
+    end
+end
 function norm_exponential(x::Float64,p::NamedTuple,b_name::Symbol)
         """
         Normalised linear function defined by (1+slope*(x-center)/260)/norm.
@@ -58,13 +67,19 @@ function norm_exponential(x::Float64,p::NamedTuple,b_name::Symbol)
         center = 1930
         range_l = [1930, 2109, 2124]
         range_h = [2099, 2114, 2190]
-
+        centers=[center,center,center]
         # could be made faster?
         R = p[Symbol(string(b_name)*"_slope")]
-
-        norm = sum(exp.(R*(center-range_l))/R)-sum(exp.(R*(center-range_h))/R)
-
-        return exp(-(x-center)*R)/norm
+        Rt=R/260
+        if (abs(Rt)>1E-6)
+           
+            norm = (-sum(exp_stable.(-Rt*(centers-range_l)))+sum(exp_stable.(-Rt*(centers-range_h))))/Rt
+        else
+            norm =240
+        end
+       
+        return exp_stable((x-center)*Rt)/norm
+    
 end
 
 

--- a/src/fitting.jl
+++ b/src/fitting.jl
@@ -47,7 +47,7 @@ function norm_uniform(x::Real,p::NamedTuple,b_name::Symbol)
 
 end
  
-function exponential(x::Float64,p::NamedTuple,b_name::Symbol)
+function norm_exponential(x::Float64,p::NamedTuple,b_name::Symbol)
         """
         Normalised linear function defined by (1+slope*(x-center)/260)/norm.
         Parameters

--- a/src/likelihood.jl
+++ b/src/likelihood.jl
@@ -9,14 +9,17 @@ using OrderedCollections
 
 
 function get_bkg_pdf(bkg_shape::Symbol,evt_energy::Float64,p::NamedTuple,b_name::Symbol)
-    
     if (bkg_shape==:uniform)
         return norm_uniform(evt_energy,p,b_name)
     elseif (bkg_shape==:linear)
         return norm_linear(evt_energy,p,b_name)
-    elseif (bkg_shape==:expo)
+    elseif (bkg_shape==:exponential)
         return norm_exponential(evt_energy,p,b_name)
+    else
+        @error "bkg shape",bkg_shape," is not yet implememnted"
+        exit(-1)
     end
+
 end
 function get_energy_scale_pars(part_k::NamedTuple,p::NamedTuple,settings::Dict,idx_part_with_events)
     """ 
@@ -121,8 +124,6 @@ free parameters: signal (S), background (B), energy bias (biask) and resolution 
 
     ll_value += logpdf(Poisson(λ), length(events_k))
 
-
-    
     for evt_energy in events_k
       
         term1 = model_b_k * get_bkg_pdf(bkg_shape,evt_energy,p, part_k.bkg_name )


### PR DESCRIPTION
PR adds the option to fit (a few) different background shapes.
The section of the config "bkg" should be modified with a block such as:

```
 "shape":{
            "name":"exponential",
            "pars":{"slope":[-10,10]}
        },
```
If this is not provided it defaults to a uniform background. The name is used to tell the code which function to use. While the parameter is set by the pars dictonary.
This will add parameters `${bkg_name}_slope` or similar to the model (and then call them). This names therefore must correspond to the names in the functions in `fitting.jl`
Currently implemented are:
* "exponential" (uses `norm_exponential(x::Float64,p::NamedTuple,b_name::Symbol)` in `fitting.jl`).
* "linear" (uses `norm_linear(x::Float64,p::NamedTuple,b_name::Symbol)` in `fitting.jl`).
* "uniform" (uses `norm_uniform(x::Float64,p::NamedTuple,b_name::Symbol)`)
In each case the function defined should take in `x` (the energy), `p` the parameters and the bkg name `b_name` and return the normalised PDF of the background.

To add a new shape simply define a new method in `fitting.jl` and a new logical condition in `get_bkg_pdf` in `likelihood.jl`

[!NOTE] some of the functions are not so optimised since the normalisation is done "on the fly" not in advance.
